### PR TITLE
Redis backend selection

### DIFF
--- a/django_cache_mock/backends/memcached.py
+++ b/django_cache_mock/backends/memcached.py
@@ -14,7 +14,7 @@ class MockcacheCache(BaseMemcachedCache):
             library=mockcache,
             value_not_found_exception=ValueError,
         )
-        self._server = server
+        self.location = server
 
     def get(self, key, default=None, version=None):
         # Override method because library don't support a default value.
@@ -28,5 +28,5 @@ class MockcacheCache(BaseMemcachedCache):
     @cached_property
     def _cache(self):
         client = super()._cache
-        client.dictionary = self._dbs.setdefault(self._server, {})
+        client.dictionary = self._dbs.setdefault(self.location, {})
         return client

--- a/django_cache_mock/backends/redis.py
+++ b/django_cache_mock/backends/redis.py
@@ -24,6 +24,7 @@ try:
         def __init__(self, server, params):
             if not server:
                 server = self.library.__name__
+            self.location = server
 
             super().__init__(server, params)
             self._lib = self.library
@@ -60,6 +61,7 @@ try:
         def __init__(self, server, params):
             if not server:
                 server = self.library.__name__
+            self.location = server
 
             super().__init__(server, params)
 

--- a/django_cache_mock/mock.py
+++ b/django_cache_mock/mock.py
@@ -4,6 +4,12 @@ SUPPORTED_BACKENDS = {
     "mockcache": "django_cache_mock.backends.memcached.MockcacheCache",
     "fakeredis": "django_cache_mock.backends.redis.FakeRedisCache",
     "redislite": "django_cache_mock.backends.redis.RedisLiteCache",
+    "fakeredis[django-redis]": (
+        "django_cache_mock.backends.redis.FakeRedisDjangoRedisCache"
+    ),
+    "redislite[django-redis]": (
+        "django_cache_mock.backends.redis.RedisLiteDjangoRedisCache"
+    ),
 }
 
 logger = logging.getLogger(__name__)

--- a/django_cache_mock/mock.py
+++ b/django_cache_mock/mock.py
@@ -17,16 +17,30 @@ logger = logging.getLogger(__name__)
 
 def patch(caches, cache_alias, backend, params=None, *, force=False):
     current_config = caches[cache_alias]
-    location = current_config.get("LOCATION")
-    if location and not force:
-        logger.debug(f"Skipped cache {cache_alias} patch because LOCATION is defined.")
-        return False
+    current_location = current_config.get("LOCATION")
 
     if params is None:
         params = {}
+
+    if current_location and not force:
+        logger.debug(f"Skipped cache {cache_alias} patch because LOCATION is defined.")
+        return False
+
+    current_backend = current_config.get("BACKEND", "")
+    backend = _redis_backend(current_backend, cache_alias, backend)
 
     params["BACKEND"] = SUPPORTED_BACKENDS[backend]
     logger.info(f"Cache {cache_alias} mocked with {backend}.")
     logger.debug(f"{params=}.")
     caches[cache_alias] = params
     return True
+
+
+def _redis_backend(current_backend, cache_alias, backend):
+    if "redis" not in backend or "django-redis" in backend:
+        return backend
+
+    if "django_redis" in current_backend:
+        backend += "[django-redis]"
+
+    return backend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,9 @@ django-redis = "*"
 
 [tool.poetry.extras]
 mockcache = ["mockcache"]
-fakeredis = ["fakeredis", "django-redis"]
-redislite = ["redislite", "django-redis"]
+fakeredis = ["fakeredis"]
+redislite = ["redislite"]
+django-redis = ["django-redis"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,3 +58,8 @@ def redis_cache_alias_not_installed(cache_alias_not_installed):
     if "redis" not in CACHES[cache_alias]["BACKEND"]:
         pytest.skip(f"Module {cache_alias} is not a redis backend.")
     return cache_alias
+
+
+@pytest.fixture(params=["fakeredis", "redislite"])
+def redis_backend(request):
+    return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,10 @@
+import importlib
 import os
 
 import pytest
 from django.core.cache import caches
+
+from tests.testapp.settings import CACHES
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -9,12 +12,49 @@ def setup_env():
     os.environ["DJANGO_SETTINGS_MODULE"] = "tests.testapp.settings"
 
 
-@pytest.fixture(params=["default", "mockcache", "fakeredis", "redislite"])
+@pytest.fixture(params=CACHES.keys())
 def cache_alias(request):
-    return os.getenv("CACHE_ALIAS", request.param)
+    return request.param
 
 
 @pytest.fixture
-def cache_cleanup(cache_alias):
-    yield
+def cache_alias_installed(cache_alias):
+    module_names = cache_alias.replace("]", "").split("[")
+    for module_name in module_names:
+        try:
+            importlib.import_module(module_name)
+        except ImportError:
+            pytest.skip(f"Module {module_name} not installed.")
+
+    yield cache_alias
     caches[cache_alias].clear()
+    del caches[cache_alias]
+
+
+@pytest.fixture
+def cache_alias_not_installed(cache_alias):
+    module_names = cache_alias.replace("]", "").split("[")
+    for module_name in module_names:
+        try:
+            importlib.import_module(module_name)
+        except ImportError:
+            pass
+        else:
+            pytest.skip(f"Module {module_name} installed.")
+    return cache_alias
+
+
+@pytest.fixture
+def memcached_cache_alias_not_installed(cache_alias_not_installed):
+    cache_alias = cache_alias_not_installed
+    if "memcached" not in CACHES[cache_alias]["BACKEND"]:
+        pytest.skip(f"Module {cache_alias} is not a memcached backend.")
+    return cache_alias
+
+
+@pytest.fixture
+def redis_cache_alias_not_installed(cache_alias_not_installed):
+    cache_alias = cache_alias_not_installed
+    if "redis" not in CACHES[cache_alias]["BACKEND"]:
+        pytest.skip(f"Module {cache_alias} is not a redis backend.")
+    return cache_alias

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -37,13 +37,13 @@ def test_server_name(cache_alias_installed, tmp_path):
         # Ignore if cache is not defined yet.
         pass
     cache = caches[cache_alias]
-    assert cache._servers == [location]
+    assert cache.location == location
     cache.set("FOO", "BAR")
     assert cache.get("FOO") == "BAR"
 
 
 def test_not_implemented_exception():
-    # Import at root level trigger
+    # Import at root level trigger https://github.com/jazzband/django-redis/issues/638.
     from django_cache_mock.backends.redis import LazyRedisCacheImportError
 
     try:
@@ -61,6 +61,7 @@ def test_not_implemented_exception():
 
 
 def test_redis_import_error(redis_cache_alias_not_installed):
+    # Import at root level trigger https://github.com/jazzband/django-redis/issues/638.
     from django_cache_mock.backends.redis import LazyRedisCacheImportError
 
     cache_alias = redis_cache_alias_not_installed

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,16 +1,12 @@
 import pytest
-from django.core.cache import caches
+from django.conf import settings
+from django.core.cache import InvalidCacheBackendError, caches
 
 from tests.thread_with_exceptions import Thread
 
 
-@pytest.fixture(autouse=True)
-def always_cleanup_cache_here(cache_cleanup):
-    pass
-
-
-def test_get_with_default_value(cache_alias):
-    cache = caches[cache_alias]
+def test_get_with_default_value(cache_alias_installed):
+    cache = caches[cache_alias_installed]
     assert cache.get("FOO", default="BOO") == "BOO"
 
 
@@ -20,7 +16,8 @@ def _threaded_assert_value(cache_alias, key, expected_value):
     assert value == expected_value
 
 
-def test_different_threads_use_same_data(cache_alias):
+def test_different_threads_use_same_data(cache_alias_installed):
+    cache_alias = cache_alias_installed
     cache = caches[cache_alias]
     key = "FOO"
     value = "BAR"
@@ -28,3 +25,58 @@ def test_different_threads_use_same_data(cache_alias):
     thread = Thread(target=_threaded_assert_value, args=(cache_alias, key, value))
     thread.start()
     thread.join()
+
+
+def test_server_name(cache_alias_installed, tmp_path):
+    cache_alias = cache_alias_installed
+    location = str(tmp_path / cache_alias)
+    settings.CACHES[cache_alias]["LOCATION"] = location
+    try:
+        del caches[cache_alias]
+    except AttributeError:
+        # Ignore if cache is not defined yet.
+        pass
+    cache = caches[cache_alias]
+    assert cache._servers == [location]
+    cache.set("FOO", "BAR")
+    assert cache.get("FOO") == "BAR"
+
+
+def test_not_implemented_exception():
+    # Import at root level trigger
+    from django_cache_mock.backends.redis import LazyRedisCacheImportError
+
+    try:
+        1 / 0
+    except ZeroDivisionError as _exc:
+
+        class MyError(LazyRedisCacheImportError):
+            exception = _exc
+
+    with pytest.raises(MyError) as exception_info:
+        MyError("server", params={})
+
+    assert isinstance(exception_info.value, MyError)
+    assert isinstance(exception_info.value.exception, ZeroDivisionError)
+
+
+def test_redis_import_error(redis_cache_alias_not_installed):
+    from django_cache_mock.backends.redis import LazyRedisCacheImportError
+
+    cache_alias = redis_cache_alias_not_installed
+    try:
+        caches[cache_alias]
+    except LazyRedisCacheImportError:
+        pass
+    else:
+        pytest.fail("Cache unexpectedly worked.")
+
+
+def test_memcached_import_error(memcached_cache_alias_not_installed):
+    cache_alias = memcached_cache_alias_not_installed
+    try:
+        caches[cache_alias]
+    except InvalidCacheBackendError:
+        pass
+    else:
+        pytest.fail("Cache unexpectedly worked.")

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -3,6 +3,7 @@ from unittest.mock import sentinel
 import pytest
 
 from django_cache_mock import patch
+from django_cache_mock.mock import SUPPORTED_BACKENDS
 
 
 def test_do_not_patch_when_location_is_defined():
@@ -33,3 +34,24 @@ def test_custom_params():
     patch(caches, "default", "mockcache", {"BAR": sentinel.bar})
     assert "FOO" not in caches["default"]
     assert caches["default"]["BAR"] == sentinel.bar
+
+
+def test_use_django_builtin_redis_based_on_backend(redis_backend):
+    caches = {"default": {"BACKEND": "django.core.cache.backends.redis.RedisCache"}}
+    patch(caches, "default", redis_backend)
+    assert caches["default"]["BACKEND"] == SUPPORTED_BACKENDS[redis_backend]
+
+
+def test_use_django_redis_based_on_backend(redis_backend):
+    caches = {"default": {"BACKEND": "django_redis.cache.RedisCache"}}
+    patch(caches, "default", redis_backend)
+    expected_backend = SUPPORTED_BACKENDS[f"{redis_backend}[django-redis]"]
+    assert caches["default"]["BACKEND"] == expected_backend
+
+
+def test_use_django_redis_explicit(redis_backend):
+    caches = {"default": {}}
+    explicit_django_redis_backend = f"{redis_backend}[django-redis]"
+    patch(caches, "default", explicit_django_redis_backend)
+    expected_backend = SUPPORTED_BACKENDS[explicit_django_redis_backend]
+    assert caches["default"]["BACKEND"] == expected_backend

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -1,16 +1,8 @@
+import django_cache_mock.mock
+
 USE_TZ = True
 
 CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-    },
-    "mockcache": {
-        "BACKEND": "django_cache_mock.backends.memcached.MockcacheCache",
-    },
-    "fakeredis": {
-        "BACKEND": "django_cache_mock.backends.redis.FakeRedisCache",
-    },
-    "redislite": {
-        "BACKEND": "django_cache_mock.backends.redis.RedisLiteCache",
-    },
+    cache_alias: {"BACKEND": cache_class}
+    for cache_alias, cache_class in django_cache_mock.mock.SUPPORTED_BACKENDS.items()
 }

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,24 @@
 [tox]
 isolated_build = true
-envlist = py{38,39,310,311}-dj{32,40,41}
+envlist = py{38,39,310,311}-dj{32,40,41},py311-dj32-nodeps
 
 [testenv]
 allowlist_externals = poetry
 commands =
-    poetry install -vvv --no-root --with dev,backends
+    poetry install --no-root --with dev,backends --all-extras
     dj32: pip install "Django>=3.2,<4.0" django-redis
     dj40: pip install "Django>=4.0,<4.1"
     dj41: pip install "Django>=4.1,<4.2"
     poetry run pytest
+
+# Environment without any extras to test all import errors.
+[testenv:py311-dj32-nodeps]
+commands =
+    poetry install --no-root --with dev
+    pip install "Django>=3.2,<4.0"
+    poetry run pytest
+    
 extras =
-    mockcache
-    fakeredis
-    redislite
 
 [gh-actions]
 python =
@@ -21,5 +26,3 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
-
-problem_matcher = false


### PR DESCRIPTION
Choose backend based on original backend or on explicit input.

Explicit input:

```python
django_cache_mock.patch("default", "redislite[django-redis]")
```